### PR TITLE
Fix type signature of takeInto

### DIFF
--- a/take-into.d.ts
+++ b/take-into.d.ts
@@ -2,4 +2,4 @@ import {default as ObliteratorIterator} from './iterator.js';
 
 // Requires a resolution of https://github.com/microsoft/TypeScript/issues/1213
 // export default function takeInto<C<~>, T>(ArrayClass: new <T>(n: number) => C<T>, iterator: Iterator<T>, n: number): C<T>;
-export default takeInto<T>(ArrayClass: new <T>(arrayLength: number) => T[], iterator: Iterator<T>, n: number): T[];
+export default function takeInto<T>(ArrayClass: new <T>(arrayLength: number) => T[], iterator: Iterator<T>, n: number): T[];

--- a/take-into.d.ts
+++ b/take-into.d.ts
@@ -1,3 +1,5 @@
 import {default as ObliteratorIterator} from './iterator.js';
 
-export default function takeInto<C, T>(ArrayClass: C, iterator: Iterator<T>, n: number): C<T>;
+// Requires a resolution of https://github.com/microsoft/TypeScript/issues/1213
+// export default function takeInto<C<~>, T>(ArrayClass: new <T>(n: number) => C<T>, iterator: Iterator<T>, n: number): C<T>;
+export default takeInto<T>(ArrayClass: new <T>(arrayLength: number) => T[], iterator: Iterator<T>, n: number): T[];


### PR DESCRIPTION
Higher order generics are not yet supported by typescript

Requires a resolution of https://github.com/microsoft/TypeScript/issues/1213 for proper typescript typings.