### PR TITLE
Add ESM import option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "obliterator",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Higher order iterator library for JavaScript/TypeScript.",
-  "main": "index.js",
+  "type": "commonjs",
   "types": "index.d.ts",
   "scripts": {
     "lint": "eslint *.js",
@@ -10,6 +10,29 @@
     "prettier": "prettier --write '*.js' '*.ts'",
     "test": "mocha test.js && npm run test:types",
     "test:types": "tsc --lib es2015,dom --noEmit --noImplicitAny --noImplicitReturns ./test-types.ts"
+  },
+  "exports": {
+    ".": {
+      "import": "./wrapper.mjs",
+      "require": "./index.js"
+    },
+    "./iterator": "./iterator.js",
+    "./chain": "./chain.js",
+    "./combinations": "./combinations.js",
+    "./consume": "./consume.js",
+    "./every": "./every.js",
+    "./filter": "./filter.js",
+    "./find": "./find.js",
+    "./foreach": "./foreach.js",
+    "./includes": "./includes.js",
+    "./iter": "./iter.js",
+    "./map": "./map.js",
+    "./match": "./match.js",
+    "./permutations": "./permutations.js",
+    "./power-set": "./power-set.js",
+    "./some": "./some.js",
+    "./split": "./split.js",
+    "./take": "./take.js"
   },
   "repository": {
     "type": "git",

--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,4 +1,4 @@
-import cjsModule from './index.cjs';
+import cjsModule from './index.js';
 
 export const Iterator = cjsModule.Iterator;
 export const iter = cjsModule.iter

--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,0 +1,22 @@
+import cjsModule from './index.cjs';
+
+export const Iterator = cjsModule.Iterator;
+export const iter = cjsModule.iter
+export const chain = cjsModule.chain
+export const combinations = cjsModule.combinations
+export const consume = cjsModule.consume
+export const every = cjsModule.every
+export const filter = cjsModule.filter
+export const find = cjsModule.find
+export const forEach = cjsModule.forEach
+export const forEachWithNullKeys = cjsModule.forEachWithNullKeys
+export const includes = cjsModule.includes
+export const map = cjsModule.map
+export const match = cjsModule.match
+export const permutations = cjsModule.permutations
+export const powerSet = cjsModule.powerSet
+export const range = cjsModule.range
+export const some = cjsModule.some
+export const split = cjsModule.split
+export const take = cjsModule.take
+export const takeInto = cjsModule.takeInto


### PR DESCRIPTION
Allow importing modules with "type": "module" to import graphology with ESM import syntax (e.g. [Graphology #382](https://github.com/graphology/graphology/issues/382)). This is intended to be a _non-breaking_ change for all users, but given the widespread adoption of obliterator and the finnicky nature of the import landscape, it should be tested carefully.

Switch from "main" to "exports" in package.json. All import paths documented in the README are added under "exports". A separate .mjs file is defined as the ESM import path for 'obliterator', which merely imports and then re-exports the files. Finally, "type": "commonjs" is explicitly specified to improve clarity, although it's not strictly necessary.

 - require('obliterator') works as before.
 - require('obliterator/iterator') and the rest work as before.
 - ESM imports of 'obliterator' work correctly.
 - ESM imports of 'obliterator/iterator' and other subpackages may not work. ESM's superior tree-shaking is the official substitute.

I saw some files, such as 'take-into.js', that were not listed as importable in the README. I left these out of the exports since they're not documented, meaning any `require('obliterator/take-into')` will cease to work. If this is not desired, I'd appreciate a full list of supported entry points.